### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,17 @@ Currently there are two available modes:
 
 ## Usage
 Once installed You will see the reading level and/or smog index displayed in the toolbar of all rich text fields in your Wagtail admin area (depending on which you added to your list of installed apps).
+
+## Known issues
+
+### Wagtail v4
+
+- This package works differently in a Wagtail v4 site. You will need to place your mouse over the richtext area to see the readings. They will show when you are entering text.
+
+### Wagtail v3
+
+- If you are using a RichTextBlock() inside a StreamField the reading level scores will not show.
+
+### Wagtail < v3
+
+- We've not tested the StreamField in this scenario, you might need to double check in your own setup to be sure.

--- a/README.rst
+++ b/README.rst
@@ -35,3 +35,18 @@ Usage
 Once installed add 'wagtailreadinglevel' to your list of installed apps AFTER all wagtail app includes (e.g. wagtail.admin, wagtail.core etc). 
   
 Once installed You will see the reading level calculation displayed in the toolbar of all rich text fields in your Wagtail admin area.
+
+Known issues
+------------
+
+Wagtail v4
+
+- This package works differently in a Wagtail v4 site. You will need to place your mouse over the richtext area to see the readings. They will show when you are entering text.
+
+Wagtail v3
+
+- If you are using a RichTextBlock() inside a StreamField the reading level scores will not show.
+
+Wagtail < v3
+
+- We've not tested the StreamField in this scenario, you might need to double check in your own setup to be sure.


### PR DESCRIPTION
This is only a documentation update about my testing on Wagtail v4

The package didn't need any changes to be made.

### Wagtail v4

- This package works differently in a Wagtail v4 site. You will need to place your mouse over the richtext area to see the readings. They will show when you are entering text.

### Wagtail v3

- If you are using a RichTextBlock() inside a StreamField the reading level scores will not show.

### Wagtail < v3

- I've not tested the StreamField in this scenario, you might need to double check in your own setup to be sure.